### PR TITLE
visualizer now also looks for bg_img in user-specified media folder

### DIFF
--- a/matrx_visualizer/static/js/gen_grid.js
+++ b/matrx_visualizer/static/js/gen_grid.js
@@ -335,7 +335,7 @@ function parse_world_settings(world_settings) {
  */
 function parse_vis_settings(vis_settings) {
     bg_colour = vis_settings['vis_bg_clr'];
-    bg_image = vis_settings['vis_bg_img'];
+    bg_image = fix_img_url(vis_settings['vis_bg_img']);
 
     // update background colour / image if needed
     draw_bg();


### PR DESCRIPTION
### Related Issue
#141 

### Those responsible
@thaije 


### Description
See #141 and the release notes below.


### Release notes
Fixed bug where background images for the visualizer from a user-specified media folder did not work. 
