### PR TITLE
Continuous bug fixing

### DIFF
--- a/matrx_visualizer/static/css/GUI.css
+++ b/matrx_visualizer/static/css/GUI.css
@@ -126,8 +126,6 @@ html {
 #messages {
     overflow-y: auto;
     max-height: 50vh;
-    display: flex;
-    flex-direction: column-reverse;
 }
 
 .message_you {

--- a/matrx_visualizer/static/js/gen_grid.js
+++ b/matrx_visualizer/static/js/gen_grid.js
@@ -32,7 +32,8 @@ var firstDraw = true,
     animation_duration_s = null, // is calculated based on animation_duration_perc and tps.
     populate_god_agent_menu = null, // keep track of any new agents
     pop_new_chat_dropdown = null,
-    latest_tick_processed = null;
+    latest_tick_processed = null,
+    redraw_required = false; // for instance when the window has been resized
 
 // tracked HTML objects
 var saved_prev_objs = {}, // obj containing the IDs of objects and their visualization settings of the previous tick
@@ -70,7 +71,7 @@ function draw(state, world_settings, new_messages, accessible_chatrooms, new_tic
     parse_world_settings(world_settings);
 
     // if we already processed this tick (MATRX is paused), stop and return
-    if (latest_tick_processed == current_tick) {
+    if (latest_tick_processed == current_tick && !redraw_required) {
         return;
     }
 
@@ -176,11 +177,10 @@ function draw(state, world_settings, new_messages, accessible_chatrooms, new_tic
 
         // set the visualization depth of this object
         obj_element.style.zIndex = obj['visualization']['depth'];
-//        obj_element.style.zIndex = 0;
 
         // if we need to style this object, e.g. because it's new or visualiation settings changed,
         // regenerate the specfic object shape with its settings
-        if (style_object) {
+        if (style_object || redraw_required) {
             set_tile_dimensions(obj_element);
 
             // draw the object with the correct shape, size and colour
@@ -203,6 +203,9 @@ function draw(state, world_settings, new_messages, accessible_chatrooms, new_tic
             return e !== objID
         })
     });
+
+    // all objects have been redrawn, so this can be set to false again
+    redraw_required = false;
 
     // any objects present in the previous tick but not present in the current
     // tick should be removed
@@ -247,6 +250,9 @@ function fix_grid_size() {
         // resize the grid to exactly encompass all tiles
         grid.style.width = tile_size * grid_size[0] + "px";
         grid.style.height = tile_size * grid_size[1] + "px";
+
+        // next time redraw all objects
+        redraw_required = true;
     }
 
     console.log("Fixed tile and grid size");

--- a/matrx_visualizer/static/js/toolbar.js
+++ b/matrx_visualizer/static/js/toolbar.js
@@ -405,10 +405,21 @@ function add_message(chat_room, mssg, type) {
     div.appendChild(document.createTextNode(mssg_content));
 
 
-
     // add the message
     var mssgs_container = document.getElementById("messages");
-    mssgs_container.insertBefore(div, mssgs_container.firstChild);
+    mssgs_container.appendChild(div);
+
+    // scroll to the new message
+    scrollSmoothToBottom(mssgs_container)
+}
+
+/**
+ * Scroll smoothly to the end of a div
+ */
+function scrollSmoothToBottom (div) {
+   $(div).animate({
+      scrollTop: div.scrollHeight - div.clientHeight
+   }, 500);
 }
 
 /*


### PR DESCRIPTION
### Related Issue
#110 
#97 
#110

### Those responsible
@thaije


### Description
- Chat now automatically scrolls down on arrival of a new message.
- Fixed chat scroll bug in Firefox.
- Fixed bug where the grid did not redraw objects when paused and the browser was resized. 

### Release notes
- Chat now automatically scrolls down on arrival of a new message.
- Fixed chat scroll bug in Firefox.
- Fixed bug where the grid did not redraw objects when paused and the browser was resized. 
