### PR TITLE
276 quick unique ids

### DIFF
--- a/matrx/cases/bw4t/bw4t.py
+++ b/matrx/cases/bw4t/bw4t.py
@@ -176,13 +176,13 @@ def create_builder():
                            visualization_bg_img="")
 
     # Add the world bounds (not needed, as agents cannot 'walk off' the grid, but for visual effect)
-    builder.add_room(top_left_location=(0, 0), width=world_size[0], height=world_size[1], name="world_bounds")
+    # builder.add_room(top_left_location=(0, 0), width=world_size[0], height=world_size[1], name="world_bounds")
 
     # Create the rooms
-    room_locations = add_rooms(builder)
+    # room_locations = add_rooms(builder)
 
     # Add the blocks the agents need to collect, we do so probabilistically so each world will contain different blocks
-    add_blocks(builder, room_locations, block_colours)
+    # add_blocks(builder, room_locations, block_colours)
 
     # Create the drop-off zones, this includes generating the random colour/shape combinations to collect.
     add_drop_off_zone(builder, world_size, block_colours, nr_blocks_to_collect=2)

--- a/matrx/cases/bw4t/bw4t_objects.py
+++ b/matrx/cases/bw4t/bw4t_objects.py
@@ -10,7 +10,7 @@ class CollectBlock(EnvObject):
 
 class SignalBlock(EnvObject):
 
-    def __init__(self, location, drop_zone_name, rank):
+    def __init__(self, name, location, drop_zone_name, rank):
         """
         """
 

--- a/matrx/cases/vis_test.py
+++ b/matrx/cases/vis_test.py
@@ -5,26 +5,75 @@ from matrx.logger.log_messages import MessageLogger
 from matrx.world_builder import WorldBuilder
 from matrx.actions import *
 from datetime import datetime
-from matrx.objects import Door, SquareBlock, AreaTile, SmokeTile, CollectionDropOffTile
-from matrx.agents import HumanAgentBrain
+
 
 
 def create_builder():
     tick_dur = 0.1
-    factory = WorldBuilder(random_seed=1, shape=[9, 10], tick_duration=1, verbose=False, run_matrx_api=True,
-                           run_matrx_visualizer=True, visualization_bg_clr="#f0f0f0", simulation_goal=100000)
+    factory = WorldBuilder(random_seed=1, shape=[14, 20], tick_duration=tick_dur, verbose=False, run_matrx_api=True,
+                           run_matrx_visualizer=True, visualization_bg_clr="#f0f0f0", simulation_goal=100000,
+                           visualization_bg_img='/static/images/restaurant_bg.png')
 
-    factory.add_room(top_left_location=[0, 0], width=9, height=10, name='Wall_Border', wall_visualize_opacity=0.5,
-                     door_locations=[(0, 1), (1, 0)], door_open_colour="#03fc0b", door_closed_colour="#fc0303",
-                     door_visualization_opacity=0.5)
-    factory.add_object(location=[3,3], name="door", callable_class=Door, visualize_opacity=0.5, is_open=False)
-    factory.add_object(location=[3,4], name="block", callable_class=SquareBlock, visualize_opacity=0.5)
-    factory.add_object(location=[3,5], name="tile1", callable_class=AreaTile, visualize_opacity=0.5)
-    factory.add_object(location=[3,6], name="tile2", callable_class=SmokeTile, visualize_opacity=0.5)
-    factory.add_object(location=[4,6], name="CollectionDropOffTile", callable_class=CollectionDropOffTile,
-                       visualize_opacity=0.5)
+    factory.add_room(top_left_location=[0, 0], width=14, height=20, name="world_bounds")
 
-    factory.add_human_agent(location=[5,6], agent=HumanAgentBrain(), visualize_opacity=0.5)
+    n_agent = 5
+
+    is_even = True
+    is_reverse = True
+    for x in range(1, n_agent + 1):
+        if is_even:
+            is_even = False
+            if is_reverse:
+                start = (x, 12)
+                waypoints = [(x, 1), (x, 11)]
+            else:
+                start = (x, 1)
+                waypoints = [(x, 11), (x, 1)]
+        else:
+            is_even = True
+            is_reverse = False
+            if is_reverse:
+                start = (1, x)
+                waypoints = [(11, x), (1, x)]
+            else:
+                start = (12, x)
+                waypoints = [(1, x), (11, x)]
+
+        navigating_agent = PatrollingAgentBrain(waypoints, move_speed=10)
+        factory.add_agent(start, navigating_agent, name="navigate " + str(x), visualization_shape=2, has_menu=True,
+                          is_traversable=False, visualize_when_busy=True)
+
+    # add human agent
+    key_action_map = {
+        'w': MoveNorth.__name__,
+        'd': MoveEast.__name__,
+        's': MoveSouth.__name__,
+        'a': MoveWest.__name__,
+        'r': RemoveObject.__name__
+    }
+    factory.add_human_agent([5, 5], HumanAgentBrain(), name="human",
+                            key_action_map=key_action_map, img_name="/static/images/transparent.png")
+
+    factory.add_human_agent([6, 6], HumanAgentBrain(), name="human2",
+                            key_action_map=key_action_map, img_name="/static/images/agent.gif", visualize_when_busy=True)
+
+    # add a number of blocks to showcase the subtile functionality
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[0,0], is_traversable=True, visualize_colour="#c0392b", visualize_shape=2)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[0,1], is_traversable=True, visualize_colour="#9b59b6", visualize_shape=1)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[0,2], is_traversable=True, visualize_colour="#2980b9", visualize_shape=0)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[1,0], is_traversable=True, visualize_colour="#1abc9c", visualize_shape=2, visualize_size=0.75)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[1,1], is_traversable=True, img_name="/static/images/fire.gif")
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[1,2], is_traversable=True, visualize_colour="#27ae60", visualize_shape=0)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[2,0], is_traversable=True, visualize_colour="#f1c40f", visualize_shape=2, visualize_size=0.5)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[2,1], is_traversable=True, visualize_colour="#e67e22", visualize_shape=1)
+    factory.add_object([6,7], "block", subtiles=[3,3], subtile_loc=[2,2], is_traversable=True, visualize_colour="#2e4053", visualize_shape=0)
+
+    # create some folders for logging
+    timestamp = str(datetime.today().strftime("%d-%m-%Y_%H-%M"))
+    log_folder = os.path.join("Results", "logs_" + timestamp)
+
+    # add loggers
+    factory.add_logger(MessageLogger, save_path=log_folder, file_name_prefix="messages_")
 
     return factory
 

--- a/matrx/objects/env_object.py
+++ b/matrx/objects/env_object.py
@@ -92,8 +92,8 @@ class EnvObject:
         if not hasattr(self, "obj_id"):
             # remove double spaces
             tmp_obj_name = " ".join(name.split())
-            # append a object ID to the end of the object name
-            self.obj_id = _ensure_unique_obj_ID(f"{tmp_obj_name}".replace(" ", "_"))
+            # create the object ID based on the object name 
+            self.obj_id = f"{tmp_obj_name}".replace(" ", "_")
 
             # prevent breaking of the frontend
             if "#" in self.obj_id:
@@ -317,29 +317,6 @@ class EnvObject:
         Here to protect the 'properties' variable. It does not do anything and should not do anything!
         """
         pass
-
-
-
-# keep track of all obj IDs added so far
-added_obj_ids = []
-
-def _ensure_unique_obj_ID(obj_id):
-    """ Make sure every obj ID is unique by adding an increasing count to objects with duplicate names.
-    Example: three objects named "drone". The object IDs will then become "drone", "drone_1", "drone_2", etc."""
-    if obj_id in added_obj_ids:
-
-        # found the next obj ID based on the obj name + count
-        i = 1
-        while f"{obj_id}_{i}" in added_obj_ids:
-            i += 1
-
-        # warnings.warn(f"There already exists an object with name {obj_id}, new object ID is: {obj_id}_{i}")
-        obj_id = f"{obj_id}_{i}"
-
-    # keep track of all object IDs we added
-    added_obj_ids.append(obj_id)
-    return obj_id
-
 
 def _get_inheritence_path(callable_class):
     """ Returns the parent's class names of the given class.

--- a/matrx/world_builder.py
+++ b/matrx/world_builder.py
@@ -1123,10 +1123,6 @@ class WorldBuilder:
                           f"{(int(location[0]), int(location[1]))}")
             location = (int(location[0]), int(location[1]))
 
-        # Load default parameters if not passed
-        if is_movable is None:
-            is_movable = defaults.ENVOBJECT_IS_MOVABLE
-
         # If default variables are not given, assign them (most empty, except
         # of sense_capability that defaults to all objects with infinite
         # range).

--- a/matrx/world_builder.py
+++ b/matrx/world_builder.py
@@ -2149,7 +2149,8 @@ class WorldBuilder:
         for idx, obj_settings in enumerate(self.object_settings):
             # Print progress (so user knows what is going on)
             if idx % max(10, int(len(self.object_settings) * 0.1)) == 0:
-                print(f"Creating objects... @{np.round(idx / len(self.object_settings) * 100, 0)}%")
+                if self.verbose:
+                    print(f"Creating objects... @{np.round(idx / len(self.object_settings) * 100, 0)}%")
 
             env_object = self.__create_env_object(obj_settings)
             if env_object is not None:
@@ -2160,7 +2161,8 @@ class WorldBuilder:
         for idx, agent_settings in enumerate(self.agent_settings):
             # Print progress (so user knows what is going on)
             if idx % max(10, int(len(self.agent_settings) * 0.1)) == 0:
-                print(f"Creating agents... @{np.round(idx / len(self.agent_settings) * 100, 0)}%")
+                if self.verbose:
+                    print(f"Creating agents... @{np.round(idx / len(self.agent_settings) * 100, 0)}%")
 
             agent, agent_avatar = self.__create_agent_avatar(agent_settings)
             if agent_avatar is not None:
@@ -2170,7 +2172,8 @@ class WorldBuilder:
         for idx, env_object in enumerate(objs):
             # Print progress (so user knows what is going on)
             if idx % max(10, int(len(objs) * 0.1)) == 0:
-                print(f"Adding objects... @{np.round(idx / len(objs) * 100, 0)}%")
+                if self.verbose:
+                    print(f"Adding objects... @{np.round(idx / len(objs) * 100, 0)}%")
 
             world._register_env_object(env_object)
 
@@ -2178,7 +2181,8 @@ class WorldBuilder:
         for idx, agent in enumerate(avatars):
             # Print progress (so user knows what is going on)
             if idx % max(10, int(len(objs) * 0.1)) == 0:
-                print(f"Adding agents... @{np.round(idx / len(avatars) * 100, 0)}%")
+                if self.verbose:
+                    print(f"Adding agents... @{np.round(idx / len(avatars) * 100, 0)}%")
             world._register_agent(agent[0], agent[1])
 
         # Register all teams and who is in them


### PR DESCRIPTION
### Related Issue
#276 
#277 

### Those responsible
@thaije


### Description
This branch contains two fixes:
- #276 fixed an issue where MATRX slowed down for multiple sequential worlds. This was fixed by a chance in how object IDs are generated. They are now if possible the same as the object name, and otherwise contain a number behind it, For example: three objects named "drone". The object IDs will then become "drone", "drone_1", "drone_2", etc. These object IDs are also reset for every new world. 
- #277  added the `verbose` check to a number of print statements


### Release notes
- A significant speed boost when creating multiple worlds in parallel or sequence. Also, object IDs are now (if possible) the same as the object name, and they reset every world! (#276)
