### PR TITLE
Temp fix for #298 - double check that state in api is a dict

### DIFF
--- a/matrx/api/api.py
+++ b/matrx/api/api.py
@@ -895,6 +895,10 @@ def __fetch_state_dicts(tick, ids=None):
         # add each agent's state for this tick
         for agent_id in ids:
             if agent_id in __states[t]:
+                # double check the state is of type dict and not a State object
+                if not isinstance(__states[t][agent_id]['state'], dict):
+                    __states[t][agent_id]['state'] = __states[t][agent_id]['state'].as_dict()
+                
                 # Get state at tick t and of agent agent_id
                 states_this_tick[agent_id] = __states[t][agent_id]
 


### PR DESCRIPTION
### Related Issue
#298 

### Those responsible
@thaije 


### Description
Temp fix for #298 


### Release notes
Fixed a bug with a temporary fix that crashed the API with the new state object (#298)
